### PR TITLE
✨ 친구 요청 사항 & 현재 친구 보여주는 뷰 생성 및 오류 수정

### DIFF
--- a/Allogdallog.xcodeproj/project.pbxproj
+++ b/Allogdallog.xcodeproj/project.pbxproj
@@ -211,14 +211,30 @@
 			path = MyPage;
 			sourceTree = "<group>";
 		};
+		35A511B22C7322A500DA8668 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Home;
+			sourceTree = "<group>";
+		};
+		35A511B42C7322C500DA8668 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				35A511972C648D3400DA8668 /* FriendsListViewModel.swift */,
+				35A5119D2C64ABAA00DA8668 /* FriendSearchViewModel.swift */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
 		35C256E22C0067FB00718555 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				35A511B42C7322C500DA8668 /* MyPage */,
+				35A511B22C7322A500DA8668 /* Home */,
 				35D259F62C3D3EE50052127B /* SignUpViewModel.swift */,
 				35D259F82C3D5E400052127B /* ImagePicker.swift */,
 				35E1F29F2C53AC7C00E163C2 /* SignInViewModel.swift */,
-				35A511972C648D3400DA8668 /* FriendsListViewModel.swift */,
-				35A5119D2C64ABAA00DA8668 /* FriendSearchViewModel.swift */,
 				35A511B02C6600CA00DA8668 /* UserViewModel.swift */,
 			);
 			path = ViewModels;

--- a/Allogdallog/Models/Friend.swift
+++ b/Allogdallog/Models/Friend.swift
@@ -11,14 +11,14 @@ struct Friend: Identifiable, Codable {
     
     var id: String
     var nickname: String = ""
-    var postUploaded: Bool = false
     var profileImageUrl: String?
+    var postUploaded: Bool = false
     
-    init(id: String, nickname: String, postUploaded: Bool = false, profileImageUrl: String) {
+    init(id: String, nickname: String, profileImageUrl: String, postUploaded: Bool = false) {
         self.id = id
         self.nickname = nickname
-        self.postUploaded = postUploaded
         self.profileImageUrl = profileImageUrl
+        self.postUploaded = postUploaded
     }
     
 }

--- a/Allogdallog/Models/FriendRequest.swift
+++ b/Allogdallog/Models/FriendRequest.swift
@@ -18,4 +18,18 @@ struct FriendRequest: Identifiable, Codable {
     var fromUserId: String
     var toUserId: String
     var status: FriendRequestStatus
+    var fromUserNick: String
+    var fromUserImgUrl: String
+    var fromUserPost: Bool
+    
+    init(id: String, fromUserId: String, toUserId: String, status: FriendRequestStatus, fromUserNick: String, fromUserImgUrl: String = "", fromUserPost: Bool) {
+        self.id = id
+        self.fromUserId = fromUserId
+        self.toUserId = toUserId
+        self.status = status
+        self.fromUserNick = fromUserNick
+        self.fromUserImgUrl = fromUserImgUrl
+        self.fromUserPost = fromUserPost
+    }
 }
+

--- a/Allogdallog/Models/User.swift
+++ b/Allogdallog/Models/User.swift
@@ -17,16 +17,10 @@ struct User: Codable, Identifiable {
     var friends: [Friend]
     var sentRequests: [FriendRequest]
     var receivedRequests: [FriendRequest]
+    var postUploaded: Bool
+    var selectedUser: String
     
-    init(id: String, email: String, friends: [Friend] = [], sentRequests: [FriendRequest] = [], receivedRequests: [FriendRequest] = []) {
-        self.id = id
-        self.email = email
-        self.friends = friends
-        self.sentRequests = sentRequests
-        self.receivedRequests = receivedRequests
-    }
-    
-    init(id: String, email: String, nickname: String, profileImageUrl: String? = nil, friends: [Friend] = [], sentRequests: [FriendRequest] = [], receivedRequests: [FriendRequest] = []) {
+    init(id: String, email: String, nickname: String = "", profileImageUrl: String? = nil, friends: [Friend] = [], sentRequests: [FriendRequest] = [], receivedRequests: [FriendRequest] = [], postUploaded: Bool = false, selectedUser: String = "") {
         self.id = id
         self.email = email
         self.nickname = nickname
@@ -34,5 +28,7 @@ struct User: Codable, Identifiable {
         self.friends = friends
         self.sentRequests = sentRequests
         self.receivedRequests = receivedRequests
+        self.postUploaded = postUploaded
+        self.selectedUser = selectedUser
     }
 }

--- a/Allogdallog/ViewModels/FriendsListViewModel.swift
+++ b/Allogdallog/ViewModels/FriendsListViewModel.swift
@@ -1,8 +1,0 @@
-//
-//  FriendsListViewModel.swift
-//  Allogdallog
-//
-//  Created by 믕진희 on 8/8/24.
-//
-
-import Foundation

--- a/Allogdallog/ViewModels/MyPage/FriendsListViewModel.swift
+++ b/Allogdallog/ViewModels/MyPage/FriendsListViewModel.swift
@@ -1,0 +1,216 @@
+//
+//  FriendsListViewModel.swift
+//  Allogdallog
+//
+//  Created by 믕진희 on 8/8/24.
+//
+
+import Foundation
+import FirebaseFirestore
+import FirebaseAuth
+
+class FriendsListViewModel: ObservableObject {
+    @Published var user: User
+    //@Published var receivedRequests: [FriendRequest] = []
+    //@Published var friends: [Friend] = []
+    
+    private var db = Firestore.firestore()
+    
+    init(user: User) {
+        self.user = user
+        //fetchFriendRequests()
+        //fetchFriends()
+    }
+
+    
+    func fetchFriendRequests() {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            print("No current user logged in")
+            return
+        }
+       
+        
+        let userRef = db.collection("users").document(currentUserID)
+            
+        userRef.getDocument { document, error in
+            if let document = document, document.exists {
+                let data = document.data()
+                
+                self.user.receivedRequests = (data?["receivedRequests"] as? [[String: Any]] ?? []).compactMap { requestData in
+                    FriendRequest(id: requestData["id"] as? String ?? "",
+                    fromUserId: requestData["fromUserId"] as? String ?? "",
+                    toUserId: requestData["toUserId"] as? String ?? "",
+                    status: FriendRequestStatus(rawValue: requestData["status"] as? String ?? "") ?? .pending,
+                    fromUserNick: requestData["fromUserNick"] as? String ?? "",
+                    fromUserImgUrl: requestData["fromUserImgUrl"] as? String ?? "",
+                    fromUserPost: requestData["fromUserPost"] as? Bool ?? false)
+                }
+
+            } else {
+                print("User document does not exist")
+            }
+        }
+    }
+     
+    
+
+    func fetchFriends() {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            print("No current user logged in")
+            return
+        }
+        
+        let userRef = db.collection("users").document(currentUserID)
+        
+        userRef.getDocument { document, error in
+            if let document = document, document.exists {
+                let data = document.data()
+                
+                self.user.friends = (data?["friends"] as? [[String: Any]] ?? []).compactMap { friendData in
+                    Friend(id: friendData["id"] as? String ?? "",
+                           nickname: friendData["nickname"] as? String ?? "",
+                           profileImageUrl: friendData["profileImageUrl"] as? String ?? "",
+                           postUploaded: friendData["postUploaded"] as? Bool ?? false)
+                }
+                
+            } else {
+                print("User document does not exist")
+            }
+        }
+    }
+
+    
+    func acceptFriendRequest(request: FriendRequest) {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            print("No current user logged in")
+            return
+        }
+        
+        let userRef = db.collection("users").document(currentUserID)
+        let friendRef = db.collection("users").document(request.fromUserId)
+       
+        userRef.updateData([
+            "friends": FieldValue.arrayUnion([[
+                "id": request.fromUserId,
+                "nickname": request.fromUserNick,
+                "profileImageUrl": request.fromUserImgUrl,
+                "postUploaded": request.fromUserPost
+            ]]),
+            "receivedRequests": FieldValue.arrayRemove([[
+                "id": request.id,
+                "fromUserId": request.fromUserId,
+                "toUserId": request.toUserId,
+                "status":  request.status.rawValue,
+                "fromUserNick": request.fromUserNick,
+                "fromUserImgUrl": request.fromUserImgUrl,
+                "fromUserPost": request.fromUserPost
+            ]])
+        ]) { error in
+            if let error = error {
+                print("Error accepting friend request: \(error)")
+            } else {
+                let newFriend = Friend(id: request.fromUserId, nickname: request.fromUserNick, profileImageUrl: request.fromUserImgUrl, postUploaded: request.fromUserPost)
+                self.user.friends.append(newFriend)
+                self.user.receivedRequests.removeAll(where: { $0.id == request.id })
+            }
+        }
+        
+        friendRef.updateData([
+            "friends": FieldValue.arrayUnion([[
+                "id": currentUserID,
+                "nickname": self.user.nickname,
+                "profileImageUrl": self.user.profileImageUrl ?? "",
+                "postUploaded": self.user.postUploaded
+            ]]),
+            "sentRequests": FieldValue.arrayRemove([[
+                "id": request.id,
+                "fromUserId": request.fromUserId,
+                "toUserId": request.toUserId,
+                "status":  request.status.rawValue,
+            ]])
+        ]) { error in
+            if let error = error {
+                print("Error updating friend's friend list: \(error)")
+            }
+        }
+    }
+    
+    func rejectFriendRequest(request: FriendRequest) {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            print("No current user logged in")
+            return
+        }
+        
+        let userRef = db.collection("users").document(currentUserID)
+        let friendRef = db.collection("users").document(request.fromUserId)
+        
+        userRef.updateData([
+            "receivedRequests": FieldValue.arrayRemove([[
+                "id": request.id,
+                "fromUserId": request.fromUserId,
+                "toUserId": request.toUserId,
+                "status": request.status.rawValue,
+                "fromUserNick": request.fromUserNick,
+                "fromUserImgUrl": request.fromUserImgUrl,
+                "fromUserPost": request.fromUserPost
+            ]])
+        ]) { error in
+            if let error = error {
+                print("Error rejecting friend request: \(error)")
+            } else {
+                self.user.receivedRequests.removeAll(where: { $0.id == request.id })
+            }
+        }
+        
+        friendRef.updateData([
+            "sentRequests": FieldValue.arrayRemove([[
+                "id": request.id,
+                "fromUserId": request.fromUserId,
+                "toUserId": request.toUserId,
+                "status":  request.status.rawValue,
+            ]])
+        ]) { error in
+            if let error = error {
+                print("Error updating friend's friend list: \(error)")
+            }
+        }
+    }
+    
+    func unfriend(friend: Friend) {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            print("No current user logged in")
+            return
+        }
+        
+        let userRef = db.collection("users").document(currentUserID)
+        let friendRef = db.collection("users").document(friend.id)
+        
+        userRef.updateData([
+            "friends": FieldValue.arrayRemove([[
+                "id": friend.id,
+                "nickname": friend.nickname,
+                "profileImageUrl": friend.profileImageUrl ?? "",
+                "postUploaded": friend.postUploaded
+            ]])
+        ]) { error in
+            if let error = error {
+                print("Error unfriending: \(error)")
+            } else {
+                self.user.friends.removeAll(where: { $0.id == friend.id })
+            }
+        }
+        
+        friendRef.updateData([
+            "friends": FieldValue.arrayRemove([[
+                "id": currentUserID,
+                "nickname": self.user.nickname,
+                "profileImageUrl": self.user.profileImageUrl ?? "",
+                "postUploaded": self.user.postUploaded
+            ]])
+        ]) { error in
+            if let error = error {
+                print("Error removing friend from their list: \(error)")
+            }
+        }
+    }
+}

--- a/Allogdallog/ViewModels/SignUpViewModel.swift
+++ b/Allogdallog/ViewModels/SignUpViewModel.swift
@@ -18,7 +18,6 @@ class SignUpViewModel: ObservableObject {
     @Published var password: String = ""
     @Published var nickname: String = ""
     @Published var profileImage: UIImage? = nil
-    @Published var friends: [Friend] = []
     @Published var errorMessage: String? = nil
     @Published var isImagePickerPresented: Bool = false
     @Published var signUpComplete: Bool = false
@@ -49,7 +48,7 @@ class SignUpViewModel: ObservableObject {
                     return
                 }
             
-                let user = User(id: uid, email: self?.email ?? "", nickname: self?.nickname ?? "", profileImageUrl: url.absoluteString, friends: [])
+                let user = User(id: uid, email: self?.email ?? "", nickname: self?.nickname ?? "", profileImageUrl: url.absoluteString, friends: [], postUploaded: false, selectedUser: uid)
                 self?.saveUserToFirestore(user: user)
                 
                 let changeRequest = Auth.auth().currentUser?.createProfileChangeRequest()

--- a/Allogdallog/ViewModels/UserViewModel.swift
+++ b/Allogdallog/ViewModels/UserViewModel.swift
@@ -12,39 +12,50 @@ class UserViewModel: ObservableObject {
             if let document = document, document.exists {
                 let data = document.data()
                 
-                let userId = data?["id"] as? String ?? ""
+                let id = data?["id"] as? String ?? ""
                 let email = data?["email"] as? String ?? ""
                 let nickname = data?["nickname"] as? String ?? ""
                 let profileImageUrl = data?["profileImageUrl"] as? String ?? ""
+                let postUploaded = data?["postUploaded"] as? Bool ?? false
+                let selectedUser = data?["selectedUser"] as? String ?? ""
                 
                 let friends = (data?["friends"] as? [[String: Any]] ?? []).compactMap { friendData in
                     Friend(id: friendData["id"] as? String ?? "",
                     nickname: friendData["nickname"] as? String ?? "",
-                    profileImageUrl: friendData["profileImageUrl"] as? String ?? "")
+                    profileImageUrl: friendData["profileImageUrl"] as? String ?? "",
+                    postUploaded: friendData["postUploaded"] as? Bool ?? false)
                 }
                 
                 let sentRequests = (data?["sentRequests"] as? [[String: Any]] ?? []).compactMap { requestData in
                     FriendRequest(id: requestData["id"] as? String ?? "",
                     fromUserId: requestData["fromUserId"] as? String ?? "",
                     toUserId: requestData["toUserId"] as? String ?? "",
-                    status: FriendRequestStatus(rawValue: requestData["status"] as? String ?? "") ?? .pending)
+                    status: FriendRequestStatus(rawValue: requestData["status"] as? String ?? "") ?? .pending,
+                    fromUserNick: requestData["fromUserNick"] as? String ?? "",
+                    fromUserImgUrl: requestData["fromUserImgUrl"] as? String ?? "",
+                    fromUserPost: requestData["fromUserPost"] as? Bool ?? false)
                 }
                 
                 let receivedRequests = (data?["receivedRequests"] as? [[String: Any]] ?? []).compactMap { requestData in
                     FriendRequest(id: requestData["id"] as? String ?? "",
                     fromUserId: requestData["fromUserId"] as? String ?? "",
                     toUserId: requestData["toUserId"] as? String ?? "",
-                    status: FriendRequestStatus(rawValue: requestData["status"] as? String ?? "") ?? .pending)
+                    status: FriendRequestStatus(rawValue: requestData["status"] as? String ?? "") ?? .pending,
+                    fromUserNick: requestData["fromUserNick"] as? String ?? "",
+                    fromUserImgUrl: requestData["fromUserImgUrl"] as? String ?? "",
+                    fromUserPost: requestData["fromUserPost"] as? Bool ?? false)
                 }
                 
                 self.user = User (
-                    id: userId,
+                    id: id,
                     email: email,
                     nickname: nickname,
                     profileImageUrl: profileImageUrl,
                     friends: friends,
                     sentRequests: sentRequests,
-                    receivedRequests: receivedRequests
+                    receivedRequests: receivedRequests,
+                    postUploaded: postUploaded,
+                    selectedUser: selectedUser
                 )
                 
             } else {

--- a/Allogdallog/Views/Home.swift
+++ b/Allogdallog/Views/Home.swift
@@ -15,7 +15,18 @@ struct Home: View {
     
     var body: some View {
         VStack {
-            MyFriends()
+            if let user = userViewModel.user {
+                MyFriends(user: user)
+            } else {
+                Text("데이터를 불러오는 중입니다.")
+                    .onAppear {
+                        if let userId = Auth.auth().currentUser?.uid {
+                            userViewModel.fetchUser(userId: userId)
+                        } else {
+                            print("User is not logged in")
+                        }
+                    }
+            }
             TabView(selection: $index) {
                 VStack {
                     if let user = userViewModel.user {
@@ -36,7 +47,20 @@ struct Home: View {
                     Label("홈", systemImage: "house.fill")
                 }
                 .tag(1)
-                Calendar()
+                VStack {
+                    if let user = userViewModel.user {
+                        FriendsList(user: user)
+                    } else {
+                        Text("데이터를 불러오는 중입니다.")
+                            .onAppear {
+                                if let userId = Auth.auth().currentUser?.uid {
+                                    userViewModel.fetchUser(userId: userId)
+                                } else {
+                                    print("User is not logged in")
+                                }
+                            }
+                    }
+                }
                     .tabItem {
                         Label("캘린더", systemImage: "calendar")
                     }

--- a/Allogdallog/Views/MyFriends.swift
+++ b/Allogdallog/Views/MyFriends.swift
@@ -8,11 +8,70 @@
 import SwiftUI
 
 struct MyFriends: View {
+    @StateObject private var viewModel: FriendsListViewModel
+    @State private var selectedUser: String?
+    
+    init(user: User) {
+        _viewModel = StateObject(wrappedValue: FriendsListViewModel(user: user))
+    }
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 16) {
+                    ForEach(viewModel.user.friends) { friend in
+                        Button(action: {
+                            selectedUser = friend.id
+                        }) {
+                            VStack {
+                                if let imageUrl = friend.profileImageUrl, let url = URL(string: imageUrl) {
+                                    AsyncImage(url: url) { phase in
+                                        switch phase {
+                                        case.empty:
+                                            Image(systemName: "person.circle")
+                                                .circularImage(size: 50)
+                                                .overlay(
+                                                    Circle().stroke(selectedUser == friend.id ? Color.blue : Color.clear, lineWidth: 4)
+                                                )
+                                        case .success(let image):
+                                            image
+                                                .resizable()
+                                                .circularImage(size: 50)
+                                                .overlay(
+                                                    Circle().stroke(selectedUser == friend.id ? Color.blue : Color.clear, lineWidth: 4)
+                                                )
+                                        case .failure:
+                                            Image(systemName: "person.circle")
+                                                .circularImage(size: 50)
+                                                .overlay(
+                                                    Circle().stroke(selectedUser == friend.id ? Color.blue : Color.clear, lineWidth: 4)
+                                                )
+                                        @unknown default:
+                                            Image(systemName: "person.circle")
+                                                .circularImage(size: 50)
+                                                .overlay(
+                                                    Circle().stroke(selectedUser == friend.id ? Color.blue : Color.clear, lineWidth: 4)
+                                                )
+                                        }
+                                    }
+                                } else {
+                                    Image(systemName: "person.circle")
+                                        .circularImage(size: 50)
+                                        .overlay(
+                                            Circle().stroke(selectedUser == friend.id ? Color.blue : Color.clear, lineWidth: 4)
+                                        )
+                                }
+                                
+                                Text(friend.nickname)
+                                    .font(.caption)
+                                    .foregroundStyle(Color.gray)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+            .padding(.vertical)
+        }
     }
 }
 
-#Preview {
-    MyFriends()
-}

--- a/Allogdallog/Views/MyPage/FriendSearch.swift
+++ b/Allogdallog/Views/MyPage/FriendSearch.swift
@@ -25,7 +25,7 @@ struct FriendSearch: View {
             
             ScrollView {
                 LazyVStack {
-                    ForEach(viewModel.searchResults) { user in
+                    ForEach(viewModel.searchResults, id: \.id) { user in
                         HStack {
                             if let imageUrl = user.profileImageUrl, let url = URL(string: imageUrl) {
                                 AsyncImage(url: url) { phase in
@@ -59,7 +59,18 @@ struct FriendSearch: View {
                             
                             Spacer()
                             
-                            if viewModel.hasSentRequest(toUser: user) {
+                            if viewModel.isFriend(userId: user.id) {
+                                Button(action: {
+                                    viewModel.unfriend(friend: Friend(id: user.id, nickname: user.nickname, profileImageUrl: user.profileImageUrl ?? "", postUploaded: user.postUploaded))
+                                }) {
+                                    Text("친구 끊기")
+                                        .font(.caption)
+                                        .padding()
+                                        .frame(height: 30)
+                                        .background(.myLightGray)
+                                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                                }
+                            } else if viewModel.hasSentRequest(toUser: user) {
                                 Text("요청됨")
                                     .font(.caption)
                                     .padding()

--- a/Allogdallog/Views/MyPage/FriendsList.swift
+++ b/Allogdallog/Views/MyPage/FriendsList.swift
@@ -8,11 +8,118 @@
 import SwiftUI
 
 struct FriendsList: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
+    
+    @StateObject private var viewModel: FriendsListViewModel
+    
+    init(user: User) {
+        _viewModel = StateObject(wrappedValue: FriendsListViewModel(user: user))
 
-#Preview {
-    FriendsList()
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("친구")
+                    .font(.headline)
+                Text("\(viewModel.user.friends.count)명")
+                    .font(.subheadline)
+                    .foregroundStyle(.gray)
+            }
+            
+            ScrollView {
+                VStack(alignment: .leading) {
+                    if !viewModel.user.receivedRequests.isEmpty {
+                        ForEach(viewModel.user.receivedRequests) { request in
+                            HStack {
+                                if let url = URL(string: request.fromUserImgUrl) {
+                                    AsyncImage(url: url) { image in
+                                        image
+                                            .resizable()
+                                            .circularImage(size: 50)
+                                    } placeholder: {
+                                        Image(systemName: "person.circle")
+                                            .circularImage(size: 50)
+                                    }
+                                } else {
+                                    Image(systemName: "person.circle")
+                                        .circularImage(size: 50)
+                                }
+                                
+                                VStack(alignment: .leading) {
+                                    Text("친구 신청")
+                                        .font(.caption)
+                                        .foregroundStyle(.gray)
+                                    Text("\(request.fromUserNick)")
+                                        .font(.subheadline)
+                                }
+                                
+                                Spacer()
+                                
+                                Button(action: {
+                                    viewModel.rejectFriendRequest(request: request)
+                                }) {
+                                    Text("거절")
+                                        .font(.caption)
+                                        .padding()
+                                        .frame(height: 30)
+                                        .background(.myLightGray)
+                                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                                }
+                                
+                                Button(action: {
+                                    viewModel.acceptFriendRequest(request: request)
+                                }) {
+                                    Text("수락")
+                                        .font(.caption)
+                                        .padding()
+                                        .frame(height: 30)
+                                        .background(.black)
+                                        .foregroundStyle(.white)
+                                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                                }
+                            }
+                        }
+                    }
+                    Divider()
+                    
+                    if !viewModel.user.friends.isEmpty {
+                        ForEach(viewModel.user.friends) { friend in
+                            HStack{
+                                if let imageUrl = friend.profileImageUrl, let url = URL(string: imageUrl) {
+                                    AsyncImage(url: url) { image in
+                                        image
+                                            .resizable()
+                                            .circularImage(size: 50)
+                                    } placeholder: {
+                                        Image(systemName: "person.circle")
+                                            .circularImage(size: 50)
+                                    }
+                                } else {
+                                    Image(systemName: "person.circle")
+                                        .circularImage(size: 50)
+                                }
+                                
+                                Text(friend.nickname)
+                                    .font(.subheadline)
+                                
+                                Spacer()
+                                
+                                Button(action: {
+                                    viewModel.unfriend(friend: friend)
+                                }) {
+                                    Text("친구 끊기")
+                                        .font(.caption)
+                                        .padding()
+                                        .frame(height: 30)
+                                        .background(.myLightGray)
+                                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal)
+    }
 }


### PR DESCRIPTION
# ✨ 친구 요청 사항 & 현재 친구 보여주는 뷰 생성 및 오류 수정
### 친구 검색 뷰
- 현재 이미 친구인 유저에게 다시 친구 요청가는 오류 수정
- 이미 친구인 유저는 친구 요청대신 친구 끊기 버튼이 위치하도록 수정

### 친구 목록 뷰
- 나에게 들어온 친구 요청들 보여주기
- 현재 나의 친구들 보여주기
- 친구 끊기기능

### 현재 내 친구들을 보여주는 뷰
- 현재 나의 친구들을 수평 스크롤뷰를 통해 보여줌

### 앞으로 해야할 일
- 친구 클릭시 홈화면에 친구의 데이터가 보이도록 하기
- 친구들 보여주는 뷰 UI 다듬기
